### PR TITLE
Update syntax unified with query syntax

### DIFF
--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/AstParser.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/AstParser.scala
@@ -10,26 +10,238 @@ import ru.tinkoff.oolong.Utils.*
 import ru.tinkoff.oolong.dsl.*
 
 private[oolong] trait AstParser {
-  def parseQExpr[Doc: Type](input: Expr[Doc => Boolean])(using quotes: Quotes): QExpr
+  def parseQExpr[Doc: Type](input: Expr[Doc => Boolean]): QExpr
 
-  def parseUExpr(input: Expr[UpdateDslNode[_]])(using quotes: Quotes): UExpr
+  def parseUExpr[Doc: Type](input: Expr[Updater[Doc] => Updater[Doc]]): UExpr
 }
 
-private[oolong] object DefaultAstParser extends AstParser {
+private[oolong] class DefaultAstParser(using quotes: Quotes) extends AstParser {
+  import quotes.reflect.*
 
   trait MakeConst[T, Ast] {
     def apply(t: T): Ast
   }
 
-  def extractConstant[T](valueOpt: Option[T])(using quotes: Quotes): T = {
-    import quotes.reflect.*
+  override def parseQExpr[Doc: Type](input: Expr[Doc => Boolean]): QExpr = {
 
-    valueOpt.getOrElse(report.errorAndAbort("Use `lift` for runtime values"))
+    given makeConst[T]: MakeConst[T, QExpr] = (t: T) => QExpr.Constant(t)
+
+    def parseIterable[T: Type](expr: Expr[Seq[T] | Set[T]]): List[QExpr] | QExpr =
+      expr match {
+        case AsIterable(elems) =>
+          elems.map {
+            case '{ $t: Boolean } => makeConst(extractConstant[Boolean](t.value))
+            case '{ $t: Long }    => makeConst(extractConstant[Long](t.value))
+            case '{ $t: Int }     => makeConst(extractConstant[Int](t.value))
+            case '{ $t: Short }   => makeConst(extractConstant[Short](t.value))
+            case '{ $t: Byte }    => makeConst(extractConstant[Byte](t.value))
+            case '{ $t: Double }  => makeConst(extractConstant[Double](t.value))
+            case '{ $t: Float }   => makeConst(extractConstant[Float](t.value))
+            case '{ $t: String }  => makeConst(extractConstant[String](t.value))
+            case '{ $t: Char }    => makeConst(extractConstant[Char](t.value))
+            case '{ lift($x: t) } => QExpr.ScalaCode(x)
+            case x                => QExpr.ScalaCode(x) // are we sure we need this this case?
+          }.toList
+        case '{ type t; lift($x: Seq[`t`] | Set[`t`]) } => QExpr.ScalaCodeIterable(x)
+        case _ =>
+          report.errorAndAbort("Unexpected expr while parsing AST: " + expr.asTerm.show(using Printer.TreeStructure))
+      }
+
+    val (paramName, rhs) = unwrapLambda(input.asTerm)
+
+    def parse(input: Expr[_]): QExpr = input match {
+      case '{ ($x: Boolean) || ($y: Boolean) } =>
+        QExpr.Or(List(parse(x), parse(y)))
+
+      case '{ ($x: Boolean) && ($y: Boolean) } =>
+        QExpr.And(List(parse(x), parse(y)))
+
+      case '{ ($x: Seq[_]).size == ($y: Int) } =>
+        QExpr.Size(parse(x), parse(y))
+
+      case '{ ($x: Seq[_]).length == ($y: Int) } =>
+        QExpr.Size(parse(x), parse(y))
+
+      case AsTerm(Apply(Select(lhs, "<="), List(rhs))) =>
+        QExpr.Lte(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Apply(Select(lhs, ">="), List(rhs))) =>
+        QExpr.Gte(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Apply(Select(lhs, "=="), List(rhs))) =>
+        QExpr.Eq(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Apply(Select(lhs, "<"), List(rhs))) =>
+        QExpr.Lt(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Apply(Select(lhs, ">"), List(rhs))) =>
+        QExpr.Gt(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Apply(Select(lhs, "!="), List(rhs))) =>
+        QExpr.Ne(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Apply(TypeApply(Select(lhs @ Select(_, _), "contains"), _), List(rhs))) =>
+        QExpr.Eq(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case AsTerm(Select(Apply(TypeApply(Select(lhs @ Select(_, _), "contains"), _), List(rhs)), "unary_!")) =>
+        QExpr.Ne(parse(lhs.asExpr), parse(rhs.asExpr))
+
+      case '{ type t; ($s: Seq[`t`]).contains($x: `t`) } =>
+        QExpr.In(parse(x), parseIterable(s))
+
+      case '{ type t; !($s: Seq[`t`]).contains($x: `t`) } =>
+        QExpr.Nin(parse(x), parseIterable(s))
+
+      case '{ type t; ($s: Set[`t`]).contains($x: `t`) } =>
+        QExpr.In(parse(x), parseIterable(s))
+
+      case '{ type t; !($s: Set[`t`]).contains($x: `t`) } =>
+        QExpr.Nin(parse(x), parseIterable(s))
+
+      case '{ ($x: Iterable[_]).isEmpty } =>
+        QExpr.Size(parse(x), QExpr.Constant(0))
+
+      case '{ ($x: Option[_]).isEmpty } =>
+        QExpr.Exists(parse(x), QExpr.Constant(false))
+
+      case '{ ($x: Option[_]).isDefined } =>
+        QExpr.Exists(parse(x), QExpr.Constant(true))
+
+      case PropSelector(name, path) if name == paramName =>
+        QExpr.Prop(path)
+
+      case '{ lift($x: t) } =>
+        QExpr.ScalaCode(x)
+
+      case '{ unchecked($x: t) } =>
+        QExpr.Subquery(x)
+
+      case '{ !($x: Boolean) } =>
+        QExpr.Not(parse(x))
+
+      case AsTerm(Literal(DoubleConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(FloatConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(LongConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(IntConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(ShortConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(ByteConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(StringConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(CharConstant(c))) =>
+        makeConst(c)
+
+      case AsTerm(Literal(BooleanConstant(c))) =>
+        makeConst(c)
+
+      case _ =>
+        report.errorAndAbort("Unexpected expr while parsing AST: " + input.show + s"; term: ${showTerm(input.asTerm)}")
+    }
+
+    parse(rhs.asExpr)
   }
 
-  def getConstant[T: Type, Ast](expr: Expr[T])(using quotes: Quotes, makeConst: MakeConst[T, Ast]): Ast = {
-    import quotes.reflect.*
+  override def parseUExpr[Doc: Type](input: Expr[Updater[Doc] => Updater[Doc]]): UExpr = {
+    given makeConst[T]: MakeConst[T, UExpr] = (t: T) => UExpr.Constant(t)
 
+    val (paramName, rhs) = unwrapLambda(input.asTerm)
+
+    // format: off
+    @tailrec
+    def parseUpdater(
+        expr: Expr[Updater[Doc]],
+        acc: List[FieldUpdateExpr]
+    ): UExpr.Update =
+      expr match {
+        case '{ type t; ($updater: Updater[Doc]).set[`t`, `t`]($selectProp, ($valueExpr:  `t`)) } =>
+          val prop  = parsePropSelector(selectProp)
+          val value = getValue(valueExpr)
+          parseUpdater(updater, FieldUpdateExpr.Set(UExpr.Prop(prop), value) :: acc)
+
+        case '{ type t; ($updater: Updater[Doc]).setOpt[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
+          val prop  = parsePropSelector(selectProp)
+          val value = getValue(valueExpr)
+          parseUpdater(updater, FieldUpdateExpr.Set(UExpr.Prop(prop), value) :: acc)
+
+        case '{type t; ($updater: Updater[Doc]).unset[`t`]($selectProp)} =>
+          val prop = parsePropSelector(selectProp)
+          parseUpdater(updater, FieldUpdateExpr.Unset(UExpr.Prop(prop)) :: acc)
+
+        case '{ type t; ($updater: Updater[Doc]).inc[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
+          Expr.summon[Numeric[t]] match {
+            case Some(_) =>
+              val prop  = parsePropSelector(selectProp)
+              val value = getValue(valueExpr)
+              parseUpdater(updater, FieldUpdateExpr.Inc(UExpr.Prop(prop), value) :: acc)
+            case _ => report.errorAndAbort(s"Trying to $$inc field that is not numeric")
+          }
+
+        case '{ type t; ($updater: Updater[Doc]).mul[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
+          Expr.summon[Numeric[t]] match {
+            case Some(_) =>
+              val prop  = parsePropSelector(selectProp)
+              val value = getValue(valueExpr)
+              parseUpdater(updater, FieldUpdateExpr.Mul(UExpr.Prop(prop), value) :: acc)
+            case _ => report.errorAndAbort(s"Trying to $$mul field that is not numeric")
+          }
+
+        case '{ type t; ($updater: Updater[Doc]).min[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
+          val prop  = parsePropSelector(selectProp)
+          val value = getValue(valueExpr)
+          parseUpdater(updater, FieldUpdateExpr.Min(UExpr.Prop(prop), value) :: acc)
+
+        case '{ type t; ($updater: Updater[Doc]).max[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
+          val prop  = parsePropSelector(selectProp)
+          val value = getValue(valueExpr)
+          parseUpdater(updater, FieldUpdateExpr.Max(UExpr.Prop(prop), value) :: acc)
+
+        case '{ type t; ($updater: Updater[Doc]).rename[`t`]($selectProp, ($valueExpr: String)) } =>
+          val prop  = parsePropSelector(selectProp)
+          val value = getValue(valueExpr)
+          parseUpdater(updater, FieldUpdateExpr.Rename(UExpr.Prop(prop), value) :: acc)
+
+        case '{ type t; ($updater: Updater[Doc]).setOnInsert[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
+          val prop  = parsePropSelector(selectProp)
+          val value = getValue(valueExpr)
+          parseUpdater(updater, FieldUpdateExpr.SetOnInsert(UExpr.Prop(prop), value) :: acc)
+
+        case '{ $updater: Updater[Doc] } =>
+          updater match {
+            case AsTerm(Ident(name)) if name == paramName =>
+              UExpr.Update(acc)
+            case _ =>
+              report.errorAndAbort(
+                s"(possibly a bug) Unexpected updater while parsing an 'update': ${updater.show}"
+              )
+          }
+
+        case _ =>
+          report.errorAndAbort(s"Unexpected expr while parsing an 'update': ${expr.show}")
+      }
+
+    parseUpdater(rhs.asExprOf[Updater[Doc]], Nil)
+  }
+  //format: on
+
+  private def showTerm(term: Term) =
+    term.show(using Printer.TreeStructure)
+
+  private def extractConstant[T](valueOpt: Option[T]): T =
+    valueOpt.getOrElse(report.errorAndAbort("Use `lift` for runtime values"))
+
+  private def getConstant[T: Type, Ast](expr: Expr[T])(using makeConst: MakeConst[T, Ast]): Ast =
     expr match {
       case '{ ${ t }: Long }    => makeConst(extractConstant(t.value))
       case '{ ${ t }: Int }     => makeConst(extractConstant(t.value))
@@ -43,16 +255,15 @@ private[oolong] object DefaultAstParser extends AstParser {
       case _ =>
         report.errorAndAbort("Unsupported constant type, consider using `lift`")
     }
-  }
 
-  override def parseQExpr[Doc: Type](input: Expr[Doc => Boolean])(using quotes: Quotes): QExpr = {
-    import quotes.reflect.*
+  private def getValue(expr: Expr[Any]): UExpr =
+    given makeConst[T]: MakeConst[T, UExpr] = (t: T) => UExpr.Constant(t)
+    expr match
+      case '{ lift($x) }     => UExpr.ScalaCode(x)
+      case '{ $constant: t } => getConstant(constant)
 
-    given makeConst[T]: MakeConst[T, QExpr] = (t: T) => QExpr.Constant(t)
-
-    def showTerm(term: Term) = term.show(using Printer.TreeStructure)
-
-    def unwrapLambda(input: Term): (String, Term) = input match {
+  private def unwrapLambda(input: Term): (String, Term) =
+    input match {
       case Inlined(_, _, expansion) =>
         unwrapLambda(expansion)
       case AnonfunBlock(paramName, body) =>
@@ -61,252 +272,18 @@ private[oolong] object DefaultAstParser extends AstParser {
         report.errorAndAbort(s"Expected a lambda, got ${showTerm(input)}")
     }
 
-    def doParse(lambdaParamName: String, lambdaBody: Expr[_]): QExpr = {
-
-      def parseIterable[T: Type](expr: Expr[Seq[T] | Set[T]])(using q: Quotes): List[QExpr] | QExpr = {
-        import q.reflect.*
-        expr match {
-          case AsIterable(elems) =>
-            elems.map {
-              case '{ $t: Boolean } => makeConst(extractConstant[Boolean](t.value))
-              case '{ $t: Long }    => makeConst(extractConstant[Long](t.value))
-              case '{ $t: Int }     => makeConst(extractConstant[Int](t.value))
-              case '{ $t: Short }   => makeConst(extractConstant[Short](t.value))
-              case '{ $t: Byte }    => makeConst(extractConstant[Byte](t.value))
-              case '{ $t: Double }  => makeConst(extractConstant[Double](t.value))
-              case '{ $t: Float }   => makeConst(extractConstant[Float](t.value))
-              case '{ $t: String }  => makeConst(extractConstant[String](t.value))
-              case '{ $t: Char }    => makeConst(extractConstant[Char](t.value))
-              case '{ lift($x: t) } => QExpr.ScalaCode(x)
-              case x                => QExpr.ScalaCode(x) // are we sure we need this this case?
-            }.toList
-          case '{ type t; lift($x: Seq[`t`] | Set[`t`]) } => QExpr.ScalaCodeIterable(x)
-          case _ =>
-            report.errorAndAbort("Unexpected expr while parsing AST: " + expr.asTerm.show(using Printer.TreeStructure))
-        }
-      }
-
-      def parse(input: Expr[_]): QExpr = input match {
-        case '{ ($x: Boolean) || ($y: Boolean) } =>
-          QExpr.Or(List(parse(x), parse(y)))
-
-        case '{ ($x: Boolean) && ($y: Boolean) } =>
-          QExpr.And(List(parse(x), parse(y)))
-
-        case '{ ($x: Seq[_]).size == ($y: Int) } =>
-          QExpr.Size(parse(x), parse(y))
-
-        case '{ ($x: Seq[_]).length == ($y: Int) } =>
-          QExpr.Size(parse(x), parse(y))
-
-        case AsTerm(Apply(Select(lhs, "<="), List(rhs))) =>
-          QExpr.Lte(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Apply(Select(lhs, ">="), List(rhs))) =>
-          QExpr.Gte(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Apply(Select(lhs, "=="), List(rhs))) =>
-          QExpr.Eq(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Apply(Select(lhs, "<"), List(rhs))) =>
-          QExpr.Lt(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Apply(Select(lhs, ">"), List(rhs))) =>
-          QExpr.Gt(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Apply(Select(lhs, "!="), List(rhs))) =>
-          QExpr.Ne(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Apply(TypeApply(Select(lhs @ Select(_, _), "contains"), _), List(rhs))) =>
-          QExpr.Eq(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case AsTerm(Select(Apply(TypeApply(Select(lhs @ Select(_, _), "contains"), _), List(rhs)), "unary_!")) =>
-          QExpr.Ne(parse(lhs.asExpr), parse(rhs.asExpr))
-
-        case '{ type t; ($s: Seq[`t`]).contains($x: `t`) } =>
-          QExpr.In(parse(x), parseIterable(s))
-
-        case '{ type t; !($s: Seq[`t`]).contains($x: `t`) } =>
-          QExpr.Nin(parse(x), parseIterable(s))
-
-        case '{ type t; ($s: Set[`t`]).contains($x: `t`) } =>
-          QExpr.In(parse(x), parseIterable(s))
-
-        case '{ type t; !($s: Set[`t`]).contains($x: `t`) } =>
-          QExpr.Nin(parse(x), parseIterable(s))
-
-        case '{ ($x: Iterable[_]).isEmpty } =>
-          QExpr.Size(parse(x), QExpr.Constant(0))
-
-        case '{ ($x: Option[_]).isEmpty } =>
-          QExpr.Exists(parse(x), QExpr.Constant(false))
-
-        case '{ ($x: Option[_]).isDefined } =>
-          QExpr.Exists(parse(x), QExpr.Constant(true))
-
-        case PropSelector(name, path) if name == lambdaParamName =>
-          QExpr.Prop(path)
-
-        case '{ lift($x: t) } =>
-          QExpr.ScalaCode(x)
-
-        case '{ unchecked($x: t) } =>
-          QExpr.Subquery(x)
-
-        case '{ !($x: Boolean) } =>
-          QExpr.Not(parse(x))
-
-        case AsTerm(Literal(DoubleConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(FloatConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(LongConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(IntConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(ShortConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(ByteConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(StringConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(CharConstant(c))) =>
-          makeConst(c)
-
-        case AsTerm(Literal(BooleanConstant(c))) =>
-          makeConst(c)
-
-        case _ =>
-          report.errorAndAbort("Unexpected expr while parsing AST: " + input.show + s"; term: ${showTerm(input.asTerm)}")
-      }
-
-      parse(lambdaBody)
-    }
-
-    val (param, rhs) = unwrapLambda(input.asTerm)
-    doParse(param, rhs.asExpr)
-  }
-
-  override def parseUExpr(input: Expr[UpdateDslNode[_]])(using quotes: Quotes): UExpr = {
-    import quotes.reflect.*
-
-    given makeConst[T]: MakeConst[T, UExpr] = (t: T) => UExpr.Constant(t)
-
-    // format: off
-    @tailrec
-    def parseUpdater[DocT](
-        expr: Expr[Updater[DocT]],
-        acc: List[FieldUpdateExpr]
-    ): UExpr.Update =
-      expr match {
-        case '{ update[docT] } =>
-          UExpr.Update(acc)
-        
-        case '{ type t; ($updater: Updater[docT]).set[`t`, `t`]($selectProp, ($valueExpr:  `t`)) } =>
-          val prop  = parsePropSelector(selectProp)
-          val value = getValue(valueExpr)
-          parseUpdater(updater, FieldUpdateExpr.Set(UExpr.Prop(prop), value) :: acc)
-
-        case '{ type t; ($updater: Updater[docT]).setOpt[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
-          val prop  = parsePropSelector(selectProp)
-          val value = getValue(valueExpr)
-          parseUpdater(updater, FieldUpdateExpr.Set(UExpr.Prop(prop), value) :: acc)
-
-        case '{type t; ($updater: Updater[docT]).unset[`t`]($selectProp)} =>
-          val prop = parsePropSelector(selectProp)
-          parseUpdater(updater, FieldUpdateExpr.Unset(UExpr.Prop(prop)) :: acc)
-
-        case '{ type t; ($updater: Updater[docT]).inc[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
-          Expr.summon[Numeric[t]] match {
-            case Some(_) =>
-              val prop  = parsePropSelector(selectProp)
-              val value = getValue(valueExpr)
-              parseUpdater(updater, FieldUpdateExpr.Inc(UExpr.Prop(prop), value) :: acc)
-            case _ => report.errorAndAbort(s"Trying to $$inc field that is not numeric")
-          }
-
-        case '{ type t; ($updater: Updater[docT]).mul[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
-          Expr.summon[Numeric[t]] match {
-            case Some(_) =>
-              val prop  = parsePropSelector(selectProp)
-              val value = getValue(valueExpr)
-              parseUpdater(updater, FieldUpdateExpr.Mul(UExpr.Prop(prop), value) :: acc)
-            case _ => report.errorAndAbort(s"Trying to $$mul field that is not numeric")
-          }
-
-        case '{ type t; ($updater: Updater[docT]).min[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
-          val prop  = parsePropSelector(selectProp)
-          val value = getValue(valueExpr)
-          parseUpdater(updater, FieldUpdateExpr.Min(UExpr.Prop(prop), value) :: acc)
-
-        case '{ type t; ($updater: Updater[docT]).max[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
-          val prop  = parsePropSelector(selectProp)
-          val value = getValue(valueExpr)
-          parseUpdater(updater, FieldUpdateExpr.Max(UExpr.Prop(prop), value) :: acc)
-
-        case '{ type t; ($updater: Updater[docT]).rename[`t`]($selectProp, ($valueExpr: String)) } =>
-          val prop  = parsePropSelector(selectProp)
-          val value = getValue(valueExpr)
-          parseUpdater(updater, FieldUpdateExpr.Rename(UExpr.Prop(prop), value) :: acc)
-
-        case '{ type t; ($updater: Updater[docT]).setOnInsert[`t`, `t`]($selectProp, ($valueExpr: `t`)) } =>
-          val prop  = parsePropSelector(selectProp)
-          val value = getValue(valueExpr)
-          parseUpdater(updater, FieldUpdateExpr.SetOnInsert(UExpr.Prop(prop), value) :: acc)
-
-        case _ =>
-          report.errorAndAbort(s"Unexpected expr while parsing an 'update': ${expr.show}")
-      }
-
-    input match {
-      case '{ $updater: Updater[docT] } => parseUpdater(updater, Nil)
-
-      case _ => report.errorAndAbort(s"Unexpected expr while parsing an AST for 'update': ${input.show}")
-    }
-  }
-  //format: on
-
-  private def getValue(expr: Expr[Any])(using Quotes): UExpr =
-    given makeConst[T]: MakeConst[T, UExpr] = (t: T) => UExpr.Constant(t)
-    expr match
-      case '{ lift($x) }     => UExpr.ScalaCode(x)
-      case '{ $constant: t } => getConstant(constant)
-
-  private def parsePropSelector[DocT, PropT](select: Expr[DocT => PropT])(using quotes: Quotes): List[String] = {
-    import quotes.reflect.*
-
-    def showTerm(term: Term) = term.show(using Printer.TreeStructure)
-
-    def extractBody(lambda: Term): Term =
+  private def parsePropSelector[DocT, PropT](select: Expr[DocT => PropT]): List[String] = {
+    def extract(lambda: Term): List[String] =
       lambda match {
         case Inlined(_, _, inlined) =>
-          extractBody(inlined)
-        case Lambda(_, body) =>
-          body
+          extract(inlined)
+        case Lambda(_, PropSelector(_, path)) =>
+          path
         case term =>
           report.errorAndAbort(s"Expected lambda, got ${showTerm(term)}")
       }
 
-    def extractSelectors(body: Term, acc: List[String] = Nil): List[String] =
-      body match {
-        case Select(from, field) =>
-          extractSelectors(from, field +: acc)
-        case Ident(_) =>
-          acc
-        case Apply(TypeApply(Ident("!!"), _), List(term)) =>
-          extractSelectors(term, acc)
-        case term =>
-          report.errorAndAbort(s"Expected selectors, got ${showTerm(term)}")
-      }
-
-    extractSelectors(extractBody(select.asTerm))
+    extract(select.asTerm)
   }
 
 }

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/Utils.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/Utils.scala
@@ -72,6 +72,10 @@ private[oolong] object Utils {
     }
 
     def unapply(using quotes: Quotes)(
+        term: quotes.reflect.Term
+    ): Option[(String, List[String])] = parse(term)
+
+    def unapply(using quotes: Quotes)(
         expr: Expr[_]
     ): Option[(String, List[String])] = {
       import quotes.reflect.*

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/dsl/Dsl.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/dsl/Dsl.scala
@@ -21,9 +21,7 @@ extension [A](a: Option[A])
    */
   def !! : A = useWithinMacro("!!")
 
-sealed trait UpdateDslNode[A]
-
-class Updater[DocT] extends UpdateDslNode[Nothing] {
+sealed trait Updater[DocT] {
   def set[PropT, ValueT](selectProp: DocT => PropT, value: ValueT)(using
       PropT =:= ValueT
   ): Updater[DocT] =
@@ -49,8 +47,4 @@ class Updater[DocT] extends UpdateDslNode[Nothing] {
   def setOnInsert[PropT, ValueT](selectProp: DocT => PropT, value: ValueT)(using
       PropT =:= ValueT,
   ): Updater[DocT] = useWithinMacro("setOnInsert")
-
 }
-
-def update[A]: Updater[A] =
-  useWithinMacro("update")

--- a/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoQueryCompiler.scala
+++ b/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoQueryCompiler.scala
@@ -104,7 +104,7 @@ object MongoQueryCompiler extends Backend[QExpr, MQ, BsonDocument] {
       case MQ.ScalaCodeIterable(_) => "?"
       case MQ.Subquery(doc)        => "{...}"
       case MQ.Field(field) =>
-        report.errorAndAbort(s"There is not filter condition on field ${field.mkString(".")}")
+        report.errorAndAbort(s"There is no filter condition on field ${field.mkString(".")}")
 
   def renderArrays(x: List[MQ] | MQ)(using Quotes): String = x match
     case list: List[MQ @unchecked] => list.map(render).mkString(", ")

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/UpdateSpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/UpdateSpec.scala
@@ -34,93 +34,65 @@ class UpdateSpec extends AnyFunSuite {
   ) derives BsonEncoder
 
   test("$set for regular fields") {
-    val q = compileUpdate {
-      update[TestClass]
-        .set(_.intField, 2)
-    }
+    val q = update[TestClass](_.set(_.intField, 2))
 
     assert(q == BsonDocument("$set" -> BsonDocument("intField" -> BsonInt32(2))))
   }
 
   test("$set for Option[_] fields") {
-    val q = compileUpdate {
-      update[TestClass]
-        .setOpt(_.optionField, 2L)
-    }
+    val q = update[TestClass](_.setOpt(_.optionField, 2L))
 
     assert(q == BsonDocument("$set" -> BsonDocument("optionField" -> BsonInt64(2))))
   }
 
   test("$inc") {
-    val q = compileUpdate {
-      update[TestClass]
-        .inc(_.intField, 1)
-    }
+    val q = update[TestClass](_.inc(_.intField, 1))
 
     assert(q == BsonDocument("$inc" -> BsonDocument("intField" -> BsonInt32(1))))
   }
 
   test("$mul") {
-    val q = compileUpdate {
-      update[TestClass]
-        .mul(_.intField, 10)
-    }
+    val q = update[TestClass](_.mul(_.intField, 10))
 
     assert(q == BsonDocument("$mul" -> BsonDocument("intField" -> BsonInt32(10))))
   }
 
   test("$max") {
-    val q = compileUpdate {
-      update[TestClass]
-        .max(_.intField, 10)
-    }
+    val q = update[TestClass](_.max(_.intField, 10))
 
     assert(q == BsonDocument("$max" -> BsonDocument("intField" -> BsonInt32(10))))
   }
 
   test("$min") {
-    val q = compileUpdate {
-      update[TestClass]
-        .min(_.intField, 10)
-    }
+    val q = update[TestClass](_.min(_.intField, 10))
 
     assert(q == BsonDocument("$min" -> BsonDocument("intField" -> BsonInt32(10))))
   }
 
   test("$rename") {
-    val q = compileUpdate {
-      update[TestClass]
-        .rename(_.intField, "newFieldName")
-    }
+    val q = update[TestClass](_.rename(_.intField, "newFieldName"))
 
     assert(q == BsonDocument("$rename" -> BsonDocument("intField" -> BsonString("newFieldName"))))
   }
 
   test("$unset") {
-    val q = compileUpdate {
-      update[TestClass]
-        .unset(_.intField)
-    }
+    val q = update[TestClass](_.unset(_.intField))
 
     assert(q == BsonDocument("$unset" -> BsonDocument("intField" -> BsonString(""))))
   }
 
   test("$setOnInsert") {
-    val q = compileUpdate {
-      update[TestClass]
-        .setOnInsert(_.intField, 14)
-    }
+    val q = update[TestClass](_.setOnInsert(_.intField, 14))
 
     assert(q == BsonDocument("$setOnInsert" -> BsonDocument("intField" -> BsonInt32(14))))
   }
 
   test("several update operators combined") {
-    val q = compileUpdate {
-      update[TestClass]
-        .unset(_.dateField)
+    val q = update[TestClass](
+      _.unset(_.dateField)
         .setOpt(_.optionField, 2L)
         .set(_.intField, 19)
-    }
+    )
 
     assert(
       q == BsonDocument(


### PR DESCRIPTION
### Problem

Syntax of update is much different from that of query.

### Solution

Make update syntax more like query syntax.

### Notes

This allows to reuse more components in parser.

@oolong/maintainers
