### PR TITLE
bump libs and remove scala-driver dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,11 @@ val `oolong-bson` = (project in file("oolong-bson"))
   .settings(Settings.common)
   .settings(
     libraryDependencies ++= Seq(
-      ("org.mongodb.scala"           %% "mongo-scala-driver" % "4.2.0").cross(CrossVersion.for3Use2_13),
-      "com.softwaremill.magnolia1_3" %% "magnolia"           % "1.1.3",
-      "org.scalatest"                %% "scalatest"          % "3.2.11"   % Test,
-      "org.scalatestplus"            %% "scalacheck-1-15"    % "3.2.11.0" % Test,
-      "org.scalacheck"               %% "scalacheck"         % "1.15.3"   % Test
+      ("org.mongodb.scala"           %% "mongo-scala-bson" % "4.6.1").cross(CrossVersion.for3Use2_13),
+      "com.softwaremill.magnolia1_3" %% "magnolia"         % "1.1.4",
+      "org.scalatest"                %% "scalatest"        % "3.2.12"   % Test,
+      "org.scalatestplus"            %% "scalacheck-1-16"  % "3.2.12.0" % Test,
+      "org.scalacheck"               %% "scalacheck"       % "1.16.0"   % Test
     ),
     Test / fork := true,
     Test / scalacOptions += "-Yretain-trees"
@@ -21,7 +21,7 @@ val `oolong-core` = (project in file("oolong-core"))
   .settings(
     libraryDependencies ++= Seq(
       "com.lihaoyi"   %% "pprint"    % "0.7.3"  % Compile,
-      "org.scalatest" %% "scalatest" % "3.2.11" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.12" % Test,
     ),
     Test / fork := true
   )
@@ -31,11 +31,12 @@ val `oolong-mongo` = (project in file("oolong-mongo"))
   .dependsOn(`oolong-core`, `oolong-bson`)
   .settings(
     libraryDependencies ++= Seq(
-      "com.dimafeng"  %% "testcontainers-scala-scalatest" % "0.40.5" % Test,
-      "com.dimafeng"  %% "testcontainers-scala-mongodb"   % "0.40.5" % Test,
-      "org.scalatest" %% "scalatest"                      % "3.2.11" % Test,
-      "org.slf4j"      % "slf4j-api"                      % "1.7.36" % Test,
-      "org.slf4j"      % "slf4j-simple"                   % "1.7.36" % Test,
+      ("org.mongodb.scala" %% "mongo-scala-driver"             % "4.6.1"  % Test).cross(CrossVersion.for3Use2_13),
+      "com.dimafeng"       %% "testcontainers-scala-scalatest" % "0.40.8" % Test,
+      "com.dimafeng"       %% "testcontainers-scala-mongodb"   % "0.40.8" % Test,
+      "org.scalatest"      %% "scalatest"                      % "3.2.12" % Test,
+      "org.slf4j"           % "slf4j-api"                      % "1.7.36" % Test,
+      "org.slf4j"           % "slf4j-simple"                   % "1.7.36" % Test,
     ),
     Test / fork := true
   )


### PR DESCRIPTION
Bump libs versions
Replace mongo-scala-driver dependency by mongo-scala-bson which we actually require

@oolong/maintainers
