### PR TITLE
Add support $type operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ val q = query[Person](p => !List(18, 19, 20).contains(p.age))
 // q is {"age": {"$nin": [18, 19, 20]}}
 ```
 
+8. $type
+
+```scala
+val q = query[Person](_.age.isInstance[MongoType.INT32])
+// q is {"age": { "$type": 16 }}
+```
+
 II Logical query operators
 
 1. $and

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/AstParser.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/AstParser.scala
@@ -159,6 +159,14 @@ private[oolong] class DefaultAstParser(using quotes: Quotes) extends AstParser {
       case InlinedSubquery(term) =>
         parse(term.asExpr)
 
+      case '{ type t; ($x: Any).isInstanceOf[`t`] } =>
+        import quotes.reflect.*
+        QExpr.TypeCheck(
+          parse(x),
+          new TypeInfo[t] {
+            override val quotedType: quoted.Type[t] = Type.of[t]
+          }
+        )
       case _ =>
         report.errorAndAbort("Unexpected expr while parsing AST: " + input.show + s"; term: ${showTerm(input.asTerm)}")
     }

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/QExpr.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/QExpr.scala
@@ -2,6 +2,7 @@ package ru.tinkoff.oolong
 
 import java.util.regex.Pattern
 import scala.quoted.Expr
+import scala.quoted.Type
 
 import ru.tinkoff.oolong.QExpr
 
@@ -24,6 +25,7 @@ private[oolong] object QExpr {
   case class Not(x: QExpr) extends QExpr
 
   case class In(x: QExpr, y: List[QExpr] | QExpr) extends QExpr
+
   case class Nin(x: QExpr, y: List[QExpr] | QExpr) extends QExpr
 
   case class And(children: List[QExpr]) extends QExpr
@@ -45,4 +47,6 @@ private[oolong] object QExpr {
   case class Size(x: QExpr, y: QExpr) extends QExpr
 
   case class Regex(x: QExpr, pattern: Expr[Pattern]) extends QExpr
+
+  case class TypeCheck[T](x: QExpr, typeInfo: TypeInfo[T]) extends QExpr
 }

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/TypeInfo.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/TypeInfo.scala
@@ -1,0 +1,6 @@
+package ru.tinkoff.oolong
+
+private[oolong] trait TypeInfo[T] {
+  type Type = T
+  implicit val quotedType: quoted.Type[T]
+}

--- a/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoQueryNode.scala
+++ b/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoQueryNode.scala
@@ -39,4 +39,6 @@ case object MongoQueryNode {
   case class Size(x: MQ) extends MQ
 
   case class Regex(pattern: Expr[Pattern]) extends MQ
+
+  case class TypeCheck(bsonType: Constant[Int]) extends MQ
 }

--- a/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoType.scala
+++ b/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoType.scala
@@ -1,0 +1,27 @@
+package ru.tinkoff.oolong.mongo
+
+object MongoType {
+
+  type DOUBLE
+  type STRING
+  type DOCUMENT
+  type ARRAY
+  type BINARY
+  type UNDEFINED
+  type OBJECT_ID
+  type BOOLEAN
+  type DATE_TIME
+  type NULL
+  type REGULAR_EXPRESSION
+  type DB_POINTER
+  type JAVASCRIPT
+  type SYMBOL
+  type JAVASCRIPT_WITH_SCOPE
+  type INT32
+  type TIMESTAMP
+  type INT64
+  type DECIMAL128
+  type MIN_KEY
+  type MAX_KEY
+
+}

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/OolongMongoSpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/OolongMongoSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import ru.tinkoff.oolong.bson.*
 import ru.tinkoff.oolong.bson.given
 import ru.tinkoff.oolong.dsl.*
+import ru.tinkoff.oolong.mongo.MongoType
 
 class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with BeforeAndAfterAll {
 
@@ -143,6 +144,22 @@ class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with Before
     for {
       res <- collection.find(q).toFuture()
     } yield assert(res.size == 1)
+  }
+
+  it should "compile queries with `.isInstance` #1" in {
+    val q = query[TestClass](_.field2.isInstanceOf[MongoType.INT32])
+
+    for {
+      res <- collection.find(q).toFuture()
+    } yield assert(res.size == 2)
+  }
+
+  it should "compile queries with `.isInstance` #2" in {
+    val q = query[TestClass](_.field3.isInstanceOf[MongoType.DOCUMENT])
+
+    for {
+      res <- collection.find(q).toFuture()
+    } yield assert(res.size == 2)
   }
 
   // TODO: test updates

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QuerySpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QuerySpec.scala
@@ -19,6 +19,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import ru.tinkoff.oolong.bson.BsonEncoder
 import ru.tinkoff.oolong.bson.given
 import ru.tinkoff.oolong.dsl.*
+import ru.tinkoff.oolong.mongo.MongoType
 
 class QuerySpec extends AnyFunSuite {
 
@@ -604,4 +605,23 @@ class QuerySpec extends AnyFunSuite {
     )
   }
 
+  test("test $type for int") {
+    val q = query[TestClass](_.intField.isInstanceOf[MongoType.INT32])
+
+    assert(
+      q == BsonDocument(
+        "intField" -> BsonDocument("$type" -> BsonInt32(16))
+      )
+    )
+  }
+
+  test("test $type for document") {
+    val q = query[TestClass](_.innerClassField.isInstanceOf[MongoType.DOCUMENT])
+
+    assert(
+      q == BsonDocument(
+        "innerClassField" -> BsonDocument("$type" -> BsonInt32(3))
+      )
+    )
+  }
 }

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QueryWithMetaSpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QueryWithMetaSpec.scala
@@ -19,6 +19,7 @@ import ru.tinkoff.oolong.bson.BsonEncoder
 import ru.tinkoff.oolong.bson.given
 import ru.tinkoff.oolong.bson.meta.QueryMeta
 import ru.tinkoff.oolong.dsl.*
+import ru.tinkoff.oolong.mongo.MongoType
 
 class QueryWithMetaSpec extends AnyFunSuite {
 
@@ -455,6 +456,26 @@ class QueryWithMetaSpec extends AnyFunSuite {
     assert(
       q == BsonDocument(
         "string_field" -> BsonDocument("$regex" -> BsonString("SomeString"))
+      )
+    )
+  }
+
+  test("test $type for int") {
+    val q = query[TestClass](_.intField.isInstanceOf[MongoType.INT32])
+
+    assert(
+      q == BsonDocument(
+        "int_field" -> BsonDocument("$type" -> BsonInt32(16))
+      )
+    )
+  }
+
+  test("test $type for document") {
+    val q = query[TestClass](_.innerClassField.isInstanceOf[MongoType.DOCUMENT])
+
+    assert(
+      q == BsonDocument(
+        "inner_class_field" -> BsonDocument("$type" -> BsonInt32(3))
       )
     )
   }


### PR DESCRIPTION
### Problem

The current DSL does not support all operators yet, particularly the $type operator. 

### Solution

This merge request adds support for this operator.
The check of model fields for type is implemented using the native Scala syntax .isInstanse[T], where T should be replaced with one of the types declared in the MongoType object.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@oolong/maintainers
