### PR TITLE
Add support $mod operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,18 @@ val q = query[Person](p => !List(18, 19, 20).contains(p.age))
 // q is {"age": {"$nin": [18, 19, 20]}}
 ```
 
-8. $type
+9. $type
 
 ```scala
 val q = query[Person](_.age.isInstance[MongoType.INT32])
 // q is {"age": { "$type": 16 }}
+```
+
+10. $mod
+
+```scala
+val q = query[Person](_.age.mod(4.5, 2))
+// q is {"age": {"$mod": [4.5, 2]}}
 ```
 
 II Logical query operators

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/AstParser.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/AstParser.scala
@@ -167,6 +167,12 @@ private[oolong] class DefaultAstParser(using quotes: Quotes) extends AstParser {
             override val quotedType: quoted.Type[t] = Type.of[t]
           }
         )
+
+      case AsTerm(
+            Apply(Apply(TypeApply(Apply(TypeApply(Ident("mod"), _), List(prop)), _), List(divisor, remainder)), _)
+          ) =>
+        QExpr.Mod(parse(prop.asExpr), parse(divisor.asExpr), parse(remainder.asExpr))
+
       case _ =>
         report.errorAndAbort("Unexpected expr while parsing AST: " + input.show + s"; term: ${showTerm(input.asTerm)}")
     }

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/QExpr.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/QExpr.scala
@@ -49,4 +49,6 @@ private[oolong] object QExpr {
   case class Regex(x: QExpr, pattern: Expr[Pattern]) extends QExpr
 
   case class TypeCheck[T](x: QExpr, typeInfo: TypeInfo[T]) extends QExpr
+
+  case class Mod(x: QExpr, divisor: QExpr, remainder: QExpr) extends QExpr
 }

--- a/oolong-core/src/main/scala/ru/tinkoff/oolong/dsl/Dsl.scala
+++ b/oolong-core/src/main/scala/ru/tinkoff/oolong/dsl/Dsl.scala
@@ -21,6 +21,9 @@ extension [A](a: Option[A])
    */
   def !! : A = useWithinMacro("!!")
 
+extension [A: Numeric](field: A)
+  def mod[D: Numeric, R: Numeric](divisor: D, remainder: R): Boolean = useWithinMacro("mod")
+
 sealed trait Updater[DocT] {
   def set[PropT, ValueT](selectProp: DocT => PropT, value: ValueT)(using
       PropT =:= ValueT

--- a/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoQueryNode.scala
+++ b/oolong-mongo/src/main/scala/ru/tinkoff/oolong/mongo/MongoQueryNode.scala
@@ -41,4 +41,6 @@ case object MongoQueryNode {
   case class Regex(pattern: Expr[Pattern]) extends MQ
 
   case class TypeCheck(bsonType: Constant[Int]) extends MQ
+
+  case class Mod(divisor: MQ, remainder: MQ) extends MQ
 }

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/OolongMongoSpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/OolongMongoSpec.scala
@@ -36,8 +36,10 @@ class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with Before
 
   override def beforeAll(): Unit = {
     val documents = List(
+      TestClass("0", 0, InnerClass("sdf"), Nil),
       TestClass("1", 1, InnerClass("qwe"), Nil),
-      TestClass("2", 2, InnerClass("asd"), Nil)
+      TestClass("2", 2, InnerClass("asd"), Nil),
+      TestClass("3", 12, InnerClass("sdf"), Nil)
     )
 
     implicit val ec = ExecutionContext.global
@@ -61,10 +63,10 @@ class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with Before
   }
 
   it should "find documents in a collection with query with runtime constant" in {
-    val q = query[TestClass](_.field2 <= lift(Random.between(3, 100)))
+    val q = query[TestClass](_.field2 <= lift(Random.between(13, 100)))
     for {
       res <- collection.find(q).toFuture()
-    } yield assert(res.size == 2)
+    } yield assert(res.size == 4)
   }
 
   it should "find both documents with OR operator" in {
@@ -95,7 +97,7 @@ class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with Before
 
     for {
       res <- collection.find(q).toFuture()
-    } yield assert(res.size == 2)
+    } yield assert(res.size == 4)
   }
 
   it should "compile queries with `unchecked`" in {
@@ -151,11 +153,27 @@ class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with Before
 
     for {
       res <- collection.find(q).toFuture()
-    } yield assert(res.size == 2)
+    } yield assert(res.size == 4)
   }
 
   it should "compile queries with `.isInstance` #2" in {
     val q = query[TestClass](_.field3.isInstanceOf[MongoType.DOCUMENT])
+
+    for {
+      res <- collection.find(q).toFuture()
+    } yield assert(res.size == 4)
+  }
+
+  it should "compile queries with `.mod` #1" in {
+    val q = query[TestClass](_.field2.mod(4, 0))
+
+    for {
+      res <- collection.find(q).toFuture()
+    } yield assert(res.size == 2)
+  }
+
+  it should "compile queries with `.mod` #2" in {
+    val q = query[TestClass](_.field2.mod(4.99, 0))
 
     for {
       res <- collection.find(q).toFuture()

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QuerySpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QuerySpec.scala
@@ -29,6 +29,7 @@ class QuerySpec extends AnyFunSuite {
 
   case class TestClass(
       intField: Int,
+      doubleField: Double,
       stringField: String,
       dateField: LocalDate,
       innerClassField: InnerClass,
@@ -621,6 +622,39 @@ class QuerySpec extends AnyFunSuite {
     assert(
       q == BsonDocument(
         "innerClassField" -> BsonDocument("$type" -> BsonInt32(3))
+      )
+    )
+  }
+  test("test $mod for int with lift(...)") {
+    val q = query[TestClass](_.intField.mod(lift(4), 5.2))
+
+    assert(
+      q == BsonDocument(
+        "intField" -> BsonDocument(
+          "$mod" -> BsonArray.fromIterable(
+            List(
+              BsonInt32(4),
+              BsonDouble(5.2)
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("test $mod for double with lift(...)") {
+    val q = query[TestClass](_.doubleField.mod(5.2, lift(123L)))
+
+    assert(
+      q == BsonDocument(
+        "doubleField" -> BsonDocument(
+          "$mod" -> BsonArray.fromIterable(
+            List(
+              BsonDouble(5.2),
+              BsonInt64(123)
+            )
+          )
+        )
       )
     )
   }

--- a/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QueryWithMetaSpec.scala
+++ b/oolong-mongo/src/test/scala/ru/tinkoff/oolong/mongo/QueryWithMetaSpec.scala
@@ -29,6 +29,7 @@ class QueryWithMetaSpec extends AnyFunSuite {
 
   case class TestClass(
       intField: Int,
+      doubleField: Double,
       stringField: String,
       dateField: LocalDate,
       innerClassField: InnerClass,
@@ -476,6 +477,40 @@ class QueryWithMetaSpec extends AnyFunSuite {
     assert(
       q == BsonDocument(
         "inner_class_field" -> BsonDocument("$type" -> BsonInt32(3))
+      )
+    )
+  }
+
+  test("test $mod for int with lift(...)") {
+    val q = query[TestClass](_.intField.mod(lift(4), 5.2))
+
+    assert(
+      q == BsonDocument(
+        "int_field" -> BsonDocument(
+          "$mod" -> BsonArray.fromIterable(
+            List(
+              BsonInt32(4),
+              BsonDouble(5.2)
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("test $mod for double with lift(...)") {
+    val q = query[TestClass](_.doubleField.mod(5.2, lift(123L)))
+
+    assert(
+      q == BsonDocument(
+        "double_field" -> BsonDocument(
+          "$mod" -> BsonArray.fromIterable(
+            List(
+              BsonDouble(5.2),
+              BsonInt64(123)
+            )
+          )
+        )
       )
     )
   }


### PR DESCRIPTION
### Problem

The current DSL does not support all operators yet, particularly the $mod operator. 

### Solution

This merge request adds support for this operator.
The operator is implemented using a new DSL .mod(...) which can be called on numeric fields. Both parameters accept both integers and floating-point numbers. It also supports lift(...).

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@oolong/maintainers
