### PR TITLE
Fix compilation using Scala 3.3.x 

### DIFF
--- a/oolong-bson/src/main/scala/ru/tinkoff/oolong/bson/meta/QueryMeta.scala
+++ b/oolong-bson/src/main/scala/ru/tinkoff/oolong/bson/meta/QueryMeta.scala
@@ -15,7 +15,7 @@ extension [T](inline q: QueryMeta[T])
 end extension
 
 object QueryMeta:
-  given [T]: FromExpr[QueryMeta[T]] = new FromExpr[QueryMeta[T]]:
+  given [T: Type]: FromExpr[QueryMeta[T]] = new FromExpr[QueryMeta[T]]:
     def unapply(expr: Expr[QueryMeta[T]])(using q: Quotes): Option[QueryMeta[T]] =
       import q.reflect.*
       expr match


### PR DESCRIPTION
Based on the build failure found in Scala 3 Open Community Build and resolved in https://github.com/lampepfl/dotty/issues/18228

### Problem

Scala 3.3.2 would fix improve typechecker, making the `given [T]: QueryMeta[T]` fail to compile, previously the type parameter was resolved to `Any` while it should be resolved to `T`.

### Solution

Adds missing implicit `Type[T]` instance

### Notes

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@oolong/maintainers
